### PR TITLE
Feature/354 upgrade exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 ### Logger ####
 logFile*.log
 /logs/
+/.env

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -1,16 +1,21 @@
 package ru.ac.checkpointmanager.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
+@Slf4j
 public class TerritoryNotFoundException extends EntityNotFoundException {
+
+    static String message;
 
     public TerritoryNotFoundException(String message) {
         super(message);
     }
 
-    public TerritoryNotFoundException(UUID territoryId, Class<?> className) {
-        super(String.format("Territory with id [%s] not found (%s)", territoryId, className));
+    public TerritoryNotFoundException(UUID territoryId) {
+        super(message = String.format("Territory with id [%s] not found", territoryId));
+        log.warn(message + " - " + this.getStackTrace()[0].toString());
     }
 }

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -8,14 +8,15 @@ import java.util.UUID;
 @Slf4j
 public class TerritoryNotFoundException extends EntityNotFoundException {
 
-    static String message;
+    public static final String MESSAGE = "Territory with id [%s] not found";
 
     public TerritoryNotFoundException(String message) {
         super(message);
+        log.warn(getMessage() + " - " + this.getStackTrace()[0].toString());
     }
 
     public TerritoryNotFoundException(UUID territoryId) {
-        super(message = "Territory with id [%s] not found".formatted(territoryId));
-        log.warn(message + " - " + this.getStackTrace()[0].toString());
+        super(MESSAGE.formatted(territoryId));
+        log.warn(getMessage() + " - " + this.getStackTrace()[0].toString());
     }
 }

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 @Slf4j
 public class TerritoryNotFoundException extends EntityNotFoundException {
 
-    static String message = null;
+    static String message;
 
     public TerritoryNotFoundException(String message) {
         super(message);

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -10,7 +10,7 @@ public class TerritoryNotFoundException extends EntityNotFoundException {
         super(message);
     }
 
-    public TerritoryNotFoundException(UUID territoryId) {
-        super(String.format("Territory with id [%s] not found", territoryId));
+    public TerritoryNotFoundException(UUID territoryId, Class<?> className) {
+        super(String.format("Territory with id [%s] not found (%s)", territoryId, className));
     }
 }

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -2,10 +2,15 @@ package ru.ac.checkpointmanager.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 
+import java.util.UUID;
+
 public class TerritoryNotFoundException extends EntityNotFoundException {
 
     public TerritoryNotFoundException(String message) {
         super(message);
     }
 
+    public TerritoryNotFoundException(UUID territoryId) {
+        super(String.format("Territory with id [%s] not found", territoryId));
+    }
 }

--- a/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/TerritoryNotFoundException.java
@@ -8,14 +8,14 @@ import java.util.UUID;
 @Slf4j
 public class TerritoryNotFoundException extends EntityNotFoundException {
 
-    static String message;
+    static String message = null;
 
     public TerritoryNotFoundException(String message) {
         super(message);
     }
 
     public TerritoryNotFoundException(UUID territoryId) {
-        super(message = String.format("Territory with id [%s] not found", territoryId));
+        super(message = "Territory with id [%s] not found".formatted(territoryId));
         log.warn(message + " - " + this.getStackTrace()[0].toString());
     }
 }

--- a/src/main/java/ru/ac/checkpointmanager/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/handler/GlobalExceptionHandler.java
@@ -52,7 +52,6 @@ public class GlobalExceptionHandler {
         ProblemDetail problemDetail = createProblemDetail(HttpStatus.NOT_FOUND, e);
         problemDetail.setTitle(ErrorMessage.OBJECT_NOT_FOUND);
         problemDetail.setProperty(ERROR_CODE, ErrorCode.NOT_FOUND.toString());
-        log.warn(e.toString());
         return problemDetail;
     }
 

--- a/src/main/java/ru/ac/checkpointmanager/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ru/ac/checkpointmanager/exception/handler/GlobalExceptionHandler.java
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
         ProblemDetail problemDetail = createProblemDetail(HttpStatus.NOT_FOUND, e);
         problemDetail.setTitle(ErrorMessage.OBJECT_NOT_FOUND);
         problemDetail.setProperty(ERROR_CODE, ErrorCode.NOT_FOUND.toString());
-        log.debug(LOG_MSG, e.getClass());
+        log.warn(e.toString());
         return problemDetail;
     }
 

--- a/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarHelperImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarHelperImpl.java
@@ -204,7 +204,7 @@ class AvatarHelperImpl implements AvatarHelper {
     public void updateTerritoryAvatar(UUID territoryId, Avatar avatar) {
         log.debug("Attempting to update avatar for user ID: {}", territoryId);
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException("This check should be not here"));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
         territory.setAvatar(avatar);
         territoryRepository.save(territory);
         log.info("Avatar updated successfully for user ID: {}", territoryId);

--- a/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImpl.java
@@ -75,7 +75,6 @@ public class AvatarServiceImpl implements AvatarService {
     @Override
     public AvatarDTO uploadAvatarByTerritory(UUID territoryId, MultipartFile avatarFile) {
         if (!territoryRepository.existsById(territoryId)) {
-            log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
             throw new TerritoryNotFoundException(territoryId);
         }
 

--- a/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImpl.java
@@ -76,8 +76,7 @@ public class AvatarServiceImpl implements AvatarService {
     public AvatarDTO uploadAvatarByTerritory(UUID territoryId, MultipartFile avatarFile) {
         if (!territoryRepository.existsById(territoryId)) {
             log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-            throw new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                    .formatted(territoryId));
+            throw new TerritoryNotFoundException(territoryId);
         }
 
         Avatar avatar = avatarHelper.getOrCreateAvatarByTerritory(territoryId);
@@ -170,12 +169,7 @@ public class AvatarServiceImpl implements AvatarService {
     public AvatarImageDTO getAvatarImageByTerritoryId(UUID territoryId) {
         log.debug("Fetching avatar image for territory id: {}", territoryId);
         Territory territory = territoryRepository.findTerritoryByIdWithAvatar(territoryId)
-                .orElseThrow(() -> {
-                            log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                            return new TerritoryNotFoundException(
-                                    ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                        }
-                );
+                .orElseThrow(() ->  new TerritoryNotFoundException(territoryId));
         Avatar avatar = territory.getAvatar();
         if (avatar == null) {
             log.warn(ExceptionUtils.AVATAR_NOT_FOUND_FOR_TERRITORY.formatted(territoryId));

--- a/src/main/java/ru/ac/checkpointmanager/service/event/impl/PassInOutViewServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/event/impl/PassInOutViewServiceImpl.java
@@ -61,8 +61,7 @@ public class PassInOutViewServiceImpl implements PassInOutViewService {
     @Override
     public Page<PassInOutView> findEventsByTerritory(UUID terId, PagingParams pagingParams) {
         if (!territoryRepository.existsById(terId)) {
-            log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(terId));
-            throw new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(terId));
+            throw new TerritoryNotFoundException(terId);
         }
         Pageable pageable = PageRequest.of(pagingParams.getPage(), pagingParams.getSize());
         return passRepository.findEventsByTerritory(terId, pageable);

--- a/src/main/java/ru/ac/checkpointmanager/service/passes/impl/PassResolverImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/passes/impl/PassResolverImpl.java
@@ -68,12 +68,7 @@ public class PassResolverImpl implements PassResolver {
                     return new UserNotFoundException(ExceptionUtils.USER_NOT_FOUND_MSG.formatted(userId));
                 });
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(
-                        () -> {
-                            log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                            return new TerritoryNotFoundException(ExceptionUtils
-                                    .TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                        });
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
         Pass pass;
         if (passCreateDTO.getCar() != null) {
             PassAuto passAuto = passMapper.toPassAuto(passCreateDTO);

--- a/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
@@ -58,14 +58,14 @@ public class TerritoryServiceImpl implements TerritoryService {
     public TerritoryDTO findById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
         return territoryMapper.toTerritoryDTO(territory);
     }
 
     @Override
     public Territory findTerritoryById(UUID territoryId) {
         return territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
     }
 
     @Override
@@ -98,7 +98,7 @@ public class TerritoryServiceImpl implements TerritoryService {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         StringTrimmer.trimThemAll(territoryDTO);
         Territory foundTerritory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
 
         if (territoryDTO.getName() != null) foundTerritory.setName(territoryDTO.getName());
         if (territoryDTO.getNote() != null) foundTerritory.setNote(territoryDTO.getNote());
@@ -114,7 +114,7 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void attachUserToTerritory(UUID territoryId, UUID userId) {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
 
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {
@@ -137,7 +137,7 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void deleteTerritoryById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         if (territoryRepository.findById(territoryId).isEmpty()) {
-            throw new TerritoryNotFoundException(territoryId, this.getClass());
+            throw new TerritoryNotFoundException(territoryId);
         }
         log.info("Territory with [id: {}] was successfully deleted", territoryId);
         territoryRepository.deleteById(territoryId);
@@ -149,7 +149,7 @@ public class TerritoryServiceImpl implements TerritoryService {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
 
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
 
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {

--- a/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
@@ -58,14 +58,14 @@ public class TerritoryServiceImpl implements TerritoryService {
     public TerritoryDTO findById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
         return territoryMapper.toTerritoryDTO(territory);
     }
 
     @Override
     public Territory findTerritoryById(UUID territoryId) {
         return territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
     }
 
     @Override
@@ -98,7 +98,7 @@ public class TerritoryServiceImpl implements TerritoryService {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         StringTrimmer.trimThemAll(territoryDTO);
         Territory foundTerritory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
 
         if (territoryDTO.getName() != null) foundTerritory.setName(territoryDTO.getName());
         if (territoryDTO.getNote() != null) foundTerritory.setNote(territoryDTO.getNote());
@@ -114,7 +114,7 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void attachUserToTerritory(UUID territoryId, UUID userId) {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
 
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {
@@ -137,7 +137,7 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void deleteTerritoryById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         if (territoryRepository.findById(territoryId).isEmpty()) {
-            throw new TerritoryNotFoundException(territoryId);
+            throw new TerritoryNotFoundException(territoryId, this.getClass());
         }
         log.info("Territory with [id: {}] was successfully deleted", territoryId);
         territoryRepository.deleteById(territoryId);
@@ -149,7 +149,7 @@ public class TerritoryServiceImpl implements TerritoryService {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
 
         Territory territory = territoryRepository.findById(territoryId)
-                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId, this.getClass()));
 
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {

--- a/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
+++ b/src/main/java/ru/ac/checkpointmanager/service/territories/TerritoryServiceImpl.java
@@ -57,23 +57,15 @@ public class TerritoryServiceImpl implements TerritoryService {
     @Override
     public TerritoryDTO findById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
-        Territory territory = territoryRepository.findById(territoryId).orElseThrow(
-                () -> {
-                    log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                    return new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                            .formatted(territoryId));
-                });
+        Territory territory = territoryRepository.findById(territoryId)
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
         return territoryMapper.toTerritoryDTO(territory);
     }
 
     @Override
     public Territory findTerritoryById(UUID territoryId) {
-        return territoryRepository.findById(territoryId).orElseThrow(
-                () -> {
-                    log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                    return new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                            .formatted(territoryId));
-                });
+        return territoryRepository.findById(territoryId)
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
     }
 
     @Override
@@ -105,12 +97,8 @@ public class TerritoryServiceImpl implements TerritoryService {
         UUID territoryId = territoryDTO.getId();
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         StringTrimmer.trimThemAll(territoryDTO);
-        Territory foundTerritory = territoryRepository.findById(territoryId).orElseThrow(
-                () -> {
-                    log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                    return new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                            .formatted(territoryId));
-                });
+        Territory foundTerritory = territoryRepository.findById(territoryId)
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
 
         if (territoryDTO.getName() != null) foundTerritory.setName(territoryDTO.getName());
         if (territoryDTO.getNote() != null) foundTerritory.setNote(territoryDTO.getNote());
@@ -125,12 +113,9 @@ public class TerritoryServiceImpl implements TerritoryService {
     @Override
     public void attachUserToTerritory(UUID territoryId, UUID userId) {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
-        Territory territory = territoryRepository.findById(territoryId).orElseThrow(
-                () -> {
-                    log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                    return new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                            .formatted(territoryId));
-                });
+        Territory territory = territoryRepository.findById(territoryId)
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {
                     log.warn(ExceptionUtils.USER_NOT_FOUND_MSG.formatted(userId));
@@ -152,8 +137,7 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void deleteTerritoryById(UUID territoryId) {
         log.debug(METHOD_CALLED_UUID_LOG, MethodLog.getMethodName(), territoryId);
         if (territoryRepository.findById(territoryId).isEmpty()) {
-            log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-            throw new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
+            throw new TerritoryNotFoundException(territoryId);
         }
         log.info("Territory with [id: {}] was successfully deleted", territoryId);
         territoryRepository.deleteById(territoryId);
@@ -164,12 +148,9 @@ public class TerritoryServiceImpl implements TerritoryService {
     public void detachUserFromTerritory(UUID territoryId, UUID userId) {
         log.debug(METHOD_USER_TERR, MethodLog.getMethodName(), userId, territoryId);
 
-        Territory territory = territoryRepository.findById(territoryId).orElseThrow(
-                () -> {
-                    log.warn(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(territoryId));
-                    return new TerritoryNotFoundException(ExceptionUtils.TERRITORY_NOT_FOUND_MSG
-                            .formatted(territoryId));
-                });
+        Territory territory = territoryRepository.findById(territoryId)
+                .orElseThrow(() -> new TerritoryNotFoundException(territoryId));
+
         User user = userRepository.findById(userId).orElseThrow(
                 () -> {
                     log.warn(ExceptionUtils.USER_NOT_FOUND_MSG.formatted(userId));

--- a/src/main/java/ru/ac/checkpointmanager/utils/TerritoryUtils.java
+++ b/src/main/java/ru/ac/checkpointmanager/utils/TerritoryUtils.java
@@ -25,7 +25,6 @@ public class TerritoryUtils {
     public static List<UUID> getTerritoryIdsOrThrow(User user, UUID userId) {
         List<Territory> territories = user.getTerritories();
         if (territories.isEmpty()) {
-            log.warn(ExceptionUtils.USER_TERRITORY_NOT_FOUND_MSG.formatted(userId));
             throw new TerritoryNotFoundException(ExceptionUtils.USER_TERRITORY_NOT_FOUND_MSG.formatted(userId));
         }
         return territories.stream()

--- a/src/test/java/ru/ac/checkpointmanager/it/controller/AvatarControllerIntegrationTest.java
+++ b/src/test/java/ru/ac/checkpointmanager/it/controller/AvatarControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.web.context.WebApplicationContext;
 import ru.ac.checkpointmanager.config.EnablePostgresAndRedisTestContainers;
 import ru.ac.checkpointmanager.config.security.WithMockCustomUser;
 import ru.ac.checkpointmanager.exception.ExceptionUtils;
+import ru.ac.checkpointmanager.exception.TerritoryNotFoundException;
 import ru.ac.checkpointmanager.model.Territory;
 import ru.ac.checkpointmanager.model.User;
 import ru.ac.checkpointmanager.model.avatar.Avatar;
@@ -137,7 +138,7 @@ class AvatarControllerIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON));
 
         resultActions.andExpect(MockMvcResultMatchers.jsonPath(TestUtils.JSON_DETAIL)
-                .value(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(TestUtils.TERR_ID)));
+                .value(TerritoryNotFoundException.MESSAGE.formatted(TestUtils.TERR_ID)));
         CheckResultActionsUtils.checkNotFoundFields(resultActions);
     }
 
@@ -181,7 +182,7 @@ class AvatarControllerIntegrationTest {
         ResultActions resultActions = mockMvc.perform(MockMvcUtils.uploadAvatarForTerritory(TestUtils.TERR_ID, file));
 
         resultActions.andExpect(MockMvcResultMatchers.jsonPath(TestUtils.JSON_DETAIL)
-                .value(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(TestUtils.TERR_ID)));
+                .value(TerritoryNotFoundException.MESSAGE.formatted(TestUtils.TERR_ID)));
         CheckResultActionsUtils.checkNotFoundFields(resultActions);
     }
 

--- a/src/test/java/ru/ac/checkpointmanager/it/controller/CrossingEventControllerIntegrationTest.java
+++ b/src/test/java/ru/ac/checkpointmanager/it/controller/CrossingEventControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import ru.ac.checkpointmanager.config.EnablePostgresAndRedisTestContainers;
 import ru.ac.checkpointmanager.exception.ExceptionUtils;
+import ru.ac.checkpointmanager.exception.TerritoryNotFoundException;
 import ru.ac.checkpointmanager.model.Territory;
 import ru.ac.checkpointmanager.model.User;
 import ru.ac.checkpointmanager.model.car.Car;
@@ -149,7 +150,7 @@ class CrossingEventControllerIntegrationTest {
 
         resultActions.andExpect(status().isNotFound())
                 .andExpectAll(jsonPath(TestUtils.JSON_DETAIL)
-                        .value(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(TestUtils.TERR_ID)));
+                        .value(TerritoryNotFoundException.MESSAGE.formatted(TestUtils.TERR_ID)));
         CheckResultActionsUtils.checkNotFoundFields(resultActions);
     }
 

--- a/src/test/java/ru/ac/checkpointmanager/service/avatar/AvatarHelperImplTest.java
+++ b/src/test/java/ru/ac/checkpointmanager/service/avatar/AvatarHelperImplTest.java
@@ -95,7 +95,7 @@ class AvatarHelperImplTest {
         Exception exception = Assertions.assertThrows(TerritoryNotFoundException.class,
                 () -> avatarHelper.updateTerritoryAvatar(territoryId, avatar));
 
-        String expectedMessage = TestUtils.ERROR_MESSAGE_SHOULD;
+        String expectedMessage = TerritoryNotFoundException.MESSAGE.formatted(territoryId);
         String actualMessage = exception.getMessage();
         Assertions.assertTrue(actualMessage.contains(expectedMessage));
         verify(territoryRepository).findById(territoryId);

--- a/src/test/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImplTest.java
+++ b/src/test/java/ru/ac/checkpointmanager/service/avatar/AvatarServiceImplTest.java
@@ -158,7 +158,7 @@ class AvatarServiceImplTest {
         TerritoryNotFoundException thrown = assertThrows(TerritoryNotFoundException.class,
                 () -> avatarService.getAvatarImageByTerritoryId(TestUtils.TERR_ID));
 
-        assertEquals(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(TestUtils.TERR_ID), thrown.getMessage());
+        assertEquals(TerritoryNotFoundException.MESSAGE.formatted(TestUtils.TERR_ID), thrown.getMessage());
         verify(territoryRepository).findTerritoryByIdWithAvatar(TestUtils.TERR_ID);
     }
 

--- a/src/test/java/ru/ac/checkpointmanager/service/event/impl/PassInOutViewServiceImplTest.java
+++ b/src/test/java/ru/ac/checkpointmanager/service/event/impl/PassInOutViewServiceImplTest.java
@@ -80,7 +80,7 @@ class PassInOutViewServiceImplTest {
         Assertions.assertThatExceptionOfType(TerritoryNotFoundException.class).isThrownBy(() ->
                         passInOutViewService.findEventsByTerritory(TestUtils.TERR_ID, pagingParams))
                 .isInstanceOf(EntityNotFoundException.class)
-                .withMessage(ExceptionUtils.TERRITORY_NOT_FOUND_MSG.formatted(TestUtils.TERR_ID));
+                .withMessage(TerritoryNotFoundException.MESSAGE.formatted(TestUtils.TERR_ID));
 
         Mockito.verify(passRepository, Mockito.never()).findEventsByTerritory(Mockito.any(), Mockito.any());
     }


### PR DESCRIPTION
(пока на примере TerritoryNotFoundException)
жутко раздражает эта нечитаемая портянка в лямбде при выбрасывании исключения, где пишется лог и исключение (при чем код формирования самого мессаджа дублируется), еще и из отдельного класса берется кусок текста, и всё это в куче скобок на куче строк.
Восхитительная альтернатива: 
1) лог пишем из экспшен хендлера (он там и так писался, но абсолютно неинформативный, а теперь пишем toString из эксепшена)
2) сообщение зашиваем в самом исключении, в конструкторе, и передаем туда всего лишь нужный параметр (в данном случае id территории)
3) profit - всё коротко, красиво, наглядно, переиспользуемо