### PR TITLE
feat(78): springdoc preload, caching, moved scheduling config to sepa…

### DIFF
--- a/src/main/java/ru/ac/checkpointmanager/CheckpointManagerApplication.java
+++ b/src/main/java/ru/ac/checkpointmanager/CheckpointManagerApplication.java
@@ -4,13 +4,11 @@ import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 
 @SpringBootApplication
-@EnableScheduling
 @EnableEncryptableProperties
 @EnableCaching
 public class CheckpointManagerApplication {

--- a/src/main/java/ru/ac/checkpointmanager/configuration/OpenApiConfig.java
+++ b/src/main/java/ru/ac/checkpointmanager/configuration/OpenApiConfig.java
@@ -14,7 +14,6 @@ import static ru.ac.checkpointmanager.utils.SwaggerConstants.SWAGGER_DESCRIPTION
 @Configuration
 public class OpenApiConfig {
 
-    private static final String CHECKPOINT_API_V_1 = "Checkpoint API: v1";
     private static final String API_V_1 = "/api/v1/**";
 
     @Value("${app.version}")
@@ -29,7 +28,7 @@ public class OpenApiConfig {
                 .addOpenApiCustomizer(openApi ->
                         openApi.addServersItem(new Server().url("https://checkpoint-manager.ru"))
                                 .info(CHP_INFO.version(appVersion)))
-                .group(CHECKPOINT_API_V_1)
+                .group("Checkpoint API: version %s".formatted(appVersion))
                 .pathsToMatch(API_V_1)
                 .build();
     }

--- a/src/main/java/ru/ac/checkpointmanager/configuration/OpenApiConfig.java
+++ b/src/main/java/ru/ac/checkpointmanager/configuration/OpenApiConfig.java
@@ -1,6 +1,5 @@
 package ru.ac.checkpointmanager.configuration;
 
-import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -15,34 +14,34 @@ import static ru.ac.checkpointmanager.utils.SwaggerConstants.SWAGGER_DESCRIPTION
 @Configuration
 public class OpenApiConfig {
 
+    private static final String CHECKPOINT_API_V_1 = "Checkpoint API: v1";
+    private static final String API_V_1 = "/api/v1/**";
+
     @Value("${app.version}")
     private String appVersion;
 
-    @Bean
-    @Profile("dev")
-    public OpenAPI openAPIDev() {
-        return new OpenAPI()
-                .addServersItem(new Server().url("http://localhost:8080"))
-                .info(new Info().title("Checkpoint Manager")
-                        .description(SWAGGER_DESCRIPTION_MESSAGE)
-                        .version(appVersion));
-    }
+    private static final Info CHP_INFO = new Info().title("Checkpoint Manager").description(SWAGGER_DESCRIPTION_MESSAGE);
 
     @Bean
     @Profile("prod")
-    public OpenAPI openAPIProd() {
-        return new OpenAPI()
-                .addServersItem(new Server().url("https://checkpoint-manager.ru"))
-                .info(new Info().title("Checkpoint Manager")
-                        .description(SWAGGER_DESCRIPTION_MESSAGE)
-                        .version(appVersion));
+    public GroupedOpenApi prodApi() {
+        return GroupedOpenApi.builder()
+                .addOpenApiCustomizer(openApi ->
+                        openApi.addServersItem(new Server().url("https://checkpoint-manager.ru"))
+                                .info(CHP_INFO.version(appVersion)))
+                .group(CHECKPOINT_API_V_1)
+                .pathsToMatch(API_V_1)
+                .build();
     }
 
     @Bean
-    public GroupedOpenApi publicApi() {
-        return GroupedOpenApi.builder()
-                .group("божественная апишечка - Enjoy using our API") //TODO потом сменить
-                .pathsToMatch("/api/**")
+    @Profile({"dev", "test"})
+    public GroupedOpenApi devApi() {
+        return GroupedOpenApi.builder().addOpenApiCustomizer(openApi ->
+                        openApi.addServersItem(new Server().url("http://localhost:8080"))
+                                .info(CHP_INFO.version(appVersion)))
+                .group("Божественная апишечка - Enjoy using our API")
+                .pathsToMatch(API_V_1)
                 .build();
     }
 }

--- a/src/main/java/ru/ac/checkpointmanager/configuration/SchedulingConfiguration.java
+++ b/src/main/java/ru/ac/checkpointmanager/configuration/SchedulingConfiguration.java
@@ -1,0 +1,9 @@
+package ru.ac.checkpointmanager.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfiguration {
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,3 +52,8 @@ cors:
 
 logging:
   config: classpath:logback-prod.xml
+
+springdoc:
+  pre-loading-enabled: true
+  cache:
+    disabled: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,6 +54,6 @@ logging:
   config: classpath:logback-prod.xml
 
 springdoc:
-  pre-loading-enabled: true
+  pre-loading-enabled: false
   cache:
     disabled: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -84,6 +84,6 @@ logging:
   config: classpath:logback-test.xml
 
 springdoc:
-  pre-loading-enabled: true
+  pre-loading-enabled: false
   cache:
     disabled: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -83,3 +83,7 @@ cors:
 logging:
   config: classpath:logback-test.xml
 
+springdoc:
+  pre-loading-enabled: true
+  cache:
+    disabled: false


### PR DESCRIPTION
Хотел сделать инициализацию сваггер доков сразу после старта, сделал - поигрался и понял что выигрише в 0.2 секунды смысла нет, вернул в фолс (учитывая еще момент, что при этой инициализации он по какой то причине грузит два бина - один базово сконфигурированный, второй уже наш)
Зато можно всю эту историю прокешировать - разрешил.

 - учитывая группировку конфигов - нет смысла в определении отдельного бина для OpenApi - перенес всю логику в группу.
 - перенес аннотацию Scheduling в отдельный конфиг (если честно уже не в первый раз задалбываюсь ее искать, конфиги должны быть с конфигами, потом в этот конфиг также добавятся ТредПулы для асинхронного работы наших джоб по расписанию)
 - 
https://ru.yougile.com/team/ed0ae40b7c09/#2SZN-78