### PR TITLE
feat(67): set log level of usertype converter to INFO

### DIFF
--- a/src/main/resources/logback-prod-docker.xml
+++ b/src/main/resources/logback-prod-docker.xml
@@ -7,7 +7,8 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan([%logger:%line]) - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan([%logger:%line]) - %msg%n
+            </pattern>
         </encoder>
     </appender>
 
@@ -45,5 +46,8 @@
         <appender-ref ref="FILE"/>
     </logger>
     <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
+
+    <!-- set logs from userType converters -->
+    <logger name="ru.ac.checkpointmanager.model.usertype" level="INFO"/>
 
 </configuration>

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -35,5 +35,6 @@
     <logger name="org.testcontainers" level="INFO"/>
     <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
     <logger name="com.github.dockerjava" level="WARN"/>
-    <logger name="ru.ac.checkpointmanager" level="debug"/>
+    <logger name="ru.ac.checkpointmanager" level="DEBUG"/>
+    <logger name="ru.ac.checkpointmanager.model.usertype" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
https://ru.yougile.com/team/ed0ae40b7c09/#2SZN-67

Изменил уровень логов из конвертера ПГ енамов в наш джавовский енам (если кто смотрел логи, то их там дофига, т.к. уровень логирования стоит ДЕБАГ), это при каждой конвертации сущности идет лог, для тестов и локальной разработки это полезно, в проде однозначно лишнее, учитывая что этих логов слишком много.

